### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC") # .order("created_at DESC")id大きい順(最近出品順)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show]
   before_action :move_to_index, except: [:index, :show, :new]
-  # before_action :move_to_session, only: [:new]
   before_action :authenticate_user!, only: [:new]
 
   def index
@@ -70,6 +69,8 @@ class ItemsController < ApplicationController
     end
   end
 
+  # before_action :authenticate_user!, only: [:new]の記述により、下記は不要！！
+  # before_action :move_to_session, only: [:new]
   # def move_to_session
   #   unless user_signed_in?
   #     redirect_to new_user_session_path

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,33 +127,35 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% if @items == true %>
-      <li class='list'>
-        <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %> <%# if item.item_image.attached? %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" if item.image.attached? %> <%# "item-sample.png" %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <%# if （「もし選択した商品に紐づく購入記録が存在していたら（空ではなかったら）、"sold out"と表示する」） %>
+                <div class='sold-out'>
+                  <%# <span>Sold Out!!</span> %>
+                </div>
+              <%# end %>
+              <%# //商品が売れていればsold outを表示しましょう %>
+
             </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
-
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= "商品名" %>
-            </h3>
-            <div class='item-price'>
-              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %> <%# "商品名" %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span> <%# "販売価格" %> <%# '配送料負担' %>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
               </div>
             </div>
-          </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
       <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -99,7 +99,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> <%# placeholedr:"半角数字で入力" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder: "半角数字で入力" %> <%# placeholedr:"半角数字で入力" "例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
フリマアプリ利用者(主に、商品購入検討者)に対し、
現在出品されている商品の一覧を提示する為。

↓一覧機能実装の様子
https://gyazo.com/85e61bb9ed3b937c24a742d72688fbe9