### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -59,9 +59,9 @@ class ItemsController < ApplicationController
     ).merge(user_id: current_user.id)
   end
 
-  # def set_item
-  #   @item = Item.find(params[:id])
-  # end
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def move_to_index
     unless user_signed_in?

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" if item.image.attached? %> <%# "item-sample.png" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,7 +134,7 @@
               <%= image_tag item.image, class: "item-img" if item.image.attached? %> <%# "item-sample.png" %>
 
               <%# 商品が売れていればsold outを表示しましょう %>
-              <%# if （「もし選択した商品に紐づく購入記録が存在していたら（空ではなかったら）、"sold out"と表示する」） %>
+              <%# if (「もし選択した商品に紐づく購入記録が存在していたら（空ではなかったら）、"sold out"と表示する」) %>
                 <div class='sold-out'>
                   <%# <span>Sold Out!!</span> %>
                 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,7 +33,7 @@
           <p class='or-text'>or</p>
           <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
         <%# end %>
-      <% elsif current_user.id != @item.user_id %>
+      <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%# if (購入記録が存在していなかったら(空だったら) %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
@@ -109,7 +109,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a> <%# "商品のカテゴリー名" %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,63 +7,68 @@
       <%= @item.name %> <%# "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <%# if (購入記録が存在していたら(空ではだったら) %>
+        <%# <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div> %>
+      <%# end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %> <%# ¥ 999,999,999 %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_fee_status.name %> <%# '配送料負担' %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう(メモ) %>
+    <% if current_user.id == @item.user_id %>
+      <%# if (購入記録が存在していなかったら(空だったら) %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%# end %>
+    <% elsif current_user.id != @item.user_id %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%# if (購入記録が存在していなかったら(空だったら) %>
+      <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# end %>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.info %></span> <%# "商品説明" %>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td> <%# "出品者名" %>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td> <%# "カテゴリー名" %>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.sales_status.name %></td> <%# "商品の状態" %>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td> <%# "発送料の負担" %>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td> <%# "発送元の地域" %>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td> <%# "発送日の目安" %>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -36,7 +36,7 @@
       <% elsif current_user.id != @item.user_id %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%# if (購入記録が存在していなかったら(空だったら) %>
-        <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
         <%# end %>
       <% end %>
       <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,19 +26,21 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう(メモ) %>
-    <% if current_user.id == @item.user_id %>
-      <%# if (購入記録が存在していなかったら(空だったら) %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-        <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-      <%# end %>
-    <% elsif current_user.id != @item.user_id %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%# if (購入記録が存在していなかったら(空だったら) %>
-      <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-      <%# end %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%# if (購入記録が存在していなかったら(空だったら) %>
+          <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+          <p class='or-text'>or</p>
+          <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%# end %>
+      <% elsif current_user.id != @item.user_id %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%# if (購入記録が存在していなかったら(空だったら) %>
+        <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# end %>
+      <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %> <%# "商品名" %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
フリマアプリ利用者が、出品された商品の詳細情報を閲覧する為。

↓詳細画面遷移の様子
出品者であるユーザーには、編集・削除ボタンを表示、「購入画面に進む」ボタンを非表示
　https://gyazo.com/65bc8530e179032d129cc9c43fed9231
出品者ではないユーザーには編集・削除ボタンを非表示、「購入画面に進む」ボタンを表示
　https://gyazo.com/2d848a3b4c2e9f56e6e1504bce333ab6
非ログインユーザーでも詳細画面閲覧可能
　https://gyazo.com/d270c823c3377481e71ce0e24af7b08e
商品詳細ページ下部：カテゴリー名表示の様子
　https://gyazo.com/e77f1a37fd9da8f2a0313af87a3080b8