### PR TITLE
エラーメッセージの日本語化機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,6 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'payjp'
+
+# 「https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml」に登録されている日本語を使用可能に。
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -311,6 +314,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails
   rubocop

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,11 +14,11 @@ class Item < ApplicationRecord
   # バリデーション
   with_options presence: true do
     validates :name                    # 商品名
-    validates :price, numericality: { only_integer: true, message: "Half-width number"} # 販売価格(数字のみ。少数不可)
+    validates :price, numericality: { only_integer: true, message: "は半角数字で入力して下さい"} # 販売価格(数字のみ。少数不可) "Half-width number"
     validates :info                    # 商品の説明
     # validate :user ← 自動
     validates :image                    # 商品画像
-    with_options numericality: { other_than: 0, message: "Select" } do # idが0以外(---除外)
+    with_options numericality: { other_than: 0, message: "を選択して下さい" } do # idが0以外(---除外) "Select"
       validates :category_id            # 商品の詳細(カテゴリー)
       validates :sales_status_id        # 商品の詳細(商品の状態)
       validates :shipping_fee_status_id # 配送について(配送料の負担)
@@ -26,7 +26,7 @@ class Item < ApplicationRecord
       validates :scheduled_delivery_id  # 配送について(発送までの日数)(=scheduled delivery,発送予定日,発送日の目安)
     end
   end
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "Out of setting range"} # 販売価格(300<=●<=999万9999)
+  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "は¥300~9,999,999の範囲で設定して下さい"} # 販売価格(300<=●<=999万9999) "Out of setting range"
 
   # def was_attached?
   #   self.image.attached?

--- a/app/models/token_address_order.rb
+++ b/app/models/token_address_order.rb
@@ -13,13 +13,13 @@ class TokenAddressOrder
     validates :item_id
     validates :user_id
     validates :token
-    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "Input correctly"} # "数字3つ + 「-」 + 数字4つ"
-    validates :prefecture_id, numericality: { other_than: 0, message: "Select" } # 配送先の県 # idが0は禁止(---除外)
+    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "はハイフンを含む数字7桁で入力して下さい"} # "数字3つ + 「-」 + 数字4つ" "Input correctly"
+    validates :prefecture_id, numericality: { other_than: 0, message: "を選択して下さい" } # 配送先の県 # idが0は禁止(---除外) "Select"
     validates :city
     validates :house_number
     # validates :building_name # 建物名はバリデーション不要(空欄可)
-    validates :phone_number, numericality: { only_integer: true, message: "Input only number"}, # 整数のみ可能
-                              length:      { in: 10..11, message: "Out of setting range"} # (数字が)10こ又は11この時だけ可
+    validates :phone_number, numericality: { only_integer: true, message: "は半角数字で入力して下さい"}, # 整数のみ可能 "Input only number"
+                              length:      { in: 10..11, message: "は10又は11桁の数値で入力して下さい"} # (数字が)10こ又は11この時だけ可 "Out of setting range"
   end
 
   def save # 保存時のメソッド。(.createは、生成 & 保存！)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,11 @@ class User < ApplicationRecord
   with_options presence: true do
     validates :nickname
     validates :birth_date
-    with_options format: { with: /\A[ぁ-んァ-ン一-龥]/, message: "Full-width characters"} do
+    with_options format: { with: /\A[ぁ-んァ-ン一-龥]/, message: "は全角で入力して下さい"} do # "Full-width characters"
       validates :firstname
       validates :lastname
     end
-    with_options format: { with: /\A[ァ-ヶー－]+\z/, message: "Full-width katakana characters"} do
+    with_options format: { with: /\A[ァ-ヶー－]+\z/, message: "は全角(カナ)で入力して下さい"} do # "Full-width katakana characters"
       validates :firstname_reading
       validates :lastname_reading
     end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,6 +8,7 @@
     </h1>
   </div>
   <div class='login-flash-message'>
+    <%# ログイン画面で、EmailとPasswordに何も入力せず投稿した場合にエラーメッセージが表示される設定 %>
     <%= flash[:notice] %>
     <%= flash[:alert] %>
   </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,3 +1,4 @@
+<%# どのモデルのバリデーションにも対応できるよう、if文にmodel.errors.any? を記述 %>
 <% if model.errors.any? %>
 <div class="error-alert">
   <ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Furima31631
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定(デフォルトenをjaに変更)
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード(確認用)
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更(%{email})のお知らせいたします。
+        message_unconfirmed:
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,34 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        birth_date: 誕生日
+        firstname: お名前(全角) 名前
+        lastname: お名前(全角) 苗字
+        # Full-width: を全角で入力して下さい
+        firstname_reading: お名前カナ(全角) 名前
+        lastname_reading: お名前カナ(全角) 苗字
+
+      item:
+        name: 商品名
+        price: 販売価格
+        info: 商品の説明
+        image: 画像
+        category_id: カテゴリー
+        sales_status_id: 商品の状態
+        shipping_fee_status_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        scheduled_delivery_id: 発送までの日数
+
+  # フォームオブジェクトの継承は、「< ApplicationRecord」ではなく「ActiveModel」な点に注意！！
+  activemodel:
+    attributes:
+      token_address_order:
+        token: カード情報
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        house_number: 番地
+        # building_name: 建物名
+        phone_number: 電話番号

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -18,98 +18,100 @@ RSpec.describe Item, type: :model do
       it "nameが空だと登録できない" do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください") # "Name can't be blank"
       end
       it "priceが空だと登録できない" do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("販売価格を入力してください") # "Price can't be blank"
       end
       it "priceが全角数字だと登録できない" do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Half-width number")
+        expect(@item.errors.full_messages).to include("販売価格は半角数字で入力して下さい") # "Price Half-width number"
       end
       it "priceが半角英字だと登録できない" do
         @item.price = 'price'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Half-width number")
+        expect(@item.errors.full_messages).to include("販売価格は半角数字で入力して下さい") # "Price Half-width number"
       end
       it "priceが300未満だと登録できない" do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include("販売価格は¥300~9,999,999の範囲で設定して下さい") # "Price Out of setting range"
       end
       it "priceが1000万以上だと登録できない" do
         @item.price = 10000000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include("販売価格は¥300~9,999,999の範囲で設定して下さい") # "Price Out of setting range"
       end
       it "infoが空だと登録できない" do
         @item.info = ""
         @item.valid?
-        expect(@item.errors.full_messages).to include("Info can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください") # "Info can't be blank"
       end
       it "imageが空だと登録できない" do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください") # "Image can't be blank"
       end
       it "category_idが空だと登録できない" do
         @item.category_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category Select")
+        expect(@item.errors.full_messages).to include("カテゴリーを選択して下さい") # "Category Select"
       end
       it "category_idが0(---)だと登録できない" do
         @item.category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category Select")
+        expect(@item.errors.full_messages).to include("カテゴリーを選択して下さい") # "Category Select"
       end
       it "sales_status_idが空だと登録できない" do
         @item.sales_status_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales status Select")
+        expect(@item.errors.full_messages).to include("商品の状態を選択して下さい") # "Sales status Select"
       end
       it "sales_status_idが0(---)だと登録できない" do
         @item.sales_status_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales status Select")
+        expect(@item.errors.full_messages).to include("商品の状態を選択して下さい") # "Sales status Select"
       end
       it "shipping_fee_status_idが空だと登録できない" do
         @item.shipping_fee_status_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee status Select")
+        expect(@item.errors.full_messages).to include("配送料の負担を選択して下さい") # "Shipping fee status Select"
       end
       it "shipping_fee_status_idが0(---)だと登録できない" do
         @item.shipping_fee_status_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee status Select")
+        expect(@item.errors.full_messages).to include("配送料の負担を選択して下さい") # "Shipping fee status Select"
       end
       it "prefecture_idが空だと登録できない" do
         @item.prefecture_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture Select")
+        expect(@item.errors.full_messages).to include("発送元の地域を選択して下さい") # "Prefecture Select"
       end
       it "prefecture_idが0(---)だと登録できない" do
         @item.prefecture_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture Select")
+        expect(@item.errors.full_messages).to include("発送元の地域を選択して下さい") # "Prefecture Select"
       end
       it "scheduled_delivery_idが空だと登録できない" do
         @item.scheduled_delivery_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Scheduled delivery Select")
+        expect(@item.errors.full_messages).to include("発送までの日数を選択して下さい") # "Scheduled delivery Select"
       end
       it "scheduled_delivery_idが0(---)だと登録できない" do
         @item.scheduled_delivery_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Scheduled delivery Select")
+        expect(@item.errors.full_messages).to include("発送までの日数を選択して下さい") # "Scheduled delivery Select"
       end
       it "ユーザーが紐付いていないとitemは登録できない" do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include("Userを入力してください") # "User must exist"
       end
     end
   end
 end
+
+# bundle exec rspec spec/models/item_spec.rb

--- a/spec/models/token_address_order_spec.rb
+++ b/spec/models/token_address_order_spec.rb
@@ -17,19 +17,19 @@ RSpec.describe TokenAddressOrder, type: :model do
       it "item_idが空では登録できないこと" do
         @order.item_id = ""
         @order.valid?
-        expect(@order.errors.full_messages).to include("Item can't be blank")
+        expect(@order.errors.full_messages).to include("Itemを入力してください") # "Item can't be blank"
       end
 
       it "user_idが空では登録できないこと" do
         @order.user_id = nil
         @order.valid?
-        expect(@order.errors.full_messages).to include("User can't be blank")
+        expect(@order.errors.full_messages).to include("Userを入力してください") # "User can't be blank"
       end
 
       it "トークン(token)が空では登録できないこと" do
         @order.token = nil
         @order.valid?
-        expect(@order.errors.full_messages).to include("Token can't be blank")
+        expect(@order.errors.full_messages).to include("カード情報を入力してください") # "Token can't be blank"
       end
 
       # it "クレジットカード情報は必須であり、正しいクレジットカードの情報で無いときは決済できないこと" do
@@ -50,73 +50,73 @@ RSpec.describe TokenAddressOrder, type: :model do
       it "郵便番号(postal_code)にはハイフン( - )が必要であること(123-4567の形とならなければならない)" do
         @order.postal_code = "1234567"
         @order.valid?
-        expect(@order.errors.full_messages).to include("Postal code Input correctly")
+        expect(@order.errors.full_messages).to include("郵便番号はハイフンを含む数字7桁で入力して下さい") # "Postal code Input correctly"
       end
 
       it "郵便番号(postal_code)にはハイフン( - )が必要で、始めが3桁でないと不可であること(123-4567の形とならなければならない)" do
         @order.postal_code = "12-3456"
         @order.valid?
-        expect(@order.errors.full_messages).to include("Postal code Input correctly")
+        expect(@order.errors.full_messages).to include("郵便番号はハイフンを含む数字7桁で入力して下さい") # "Postal code Input correctly"
       end
 
       it "郵便番号(postal_code)にはハイフン( - )が必要で、終わりが4桁でないと不可であること(123-4567の形とならなければならない)" do
         @order.postal_code = "123-45678"
         @order.valid?
-        expect(@order.errors.full_messages).to include("Postal code Input correctly")
+        expect(@order.errors.full_messages).to include("郵便番号はハイフンを含む数字7桁で入力して下さい") # "Postal code Input correctly"
       end
 
       it "郵便番号(postal_code)が空では購入できない" do
         @order.postal_code = ""
         @order.valid?
-        expect(@order.errors.full_messages).to include("Postal code can't be blank")
+        expect(@order.errors.full_messages).to include("郵便番号を入力してください") # "Postal code can't be blank"
       end
 
       it "都道府県(prefecture_id)が空では購入できない" do
         @order.prefecture_id = ""
         @order.valid?
-        expect(@order.errors.full_messages).to include("Prefecture Select")
+        expect(@order.errors.full_messages).to include("都道府県を選択して下さい") # "Prefecture Select"
       end
 
       it "都道府県(prefecture_id)が0(---)だと登録できない" do
         @order.prefecture_id = 0
         @order.valid?
-        expect(@order.errors.full_messages).to include("Prefecture Select")
+        expect(@order.errors.full_messages).to include("都道府県を選択して下さい") # "Prefecture Select"
       end
 
       it "市区町村(city)が空では購入できない" do
         @order.city = ""
         @order.valid?
-        expect(@order.errors.full_messages).to include("City can't be blank")
+        expect(@order.errors.full_messages).to include("市区町村を入力してください") #
       end
 
       it "番地(house_number)が空では購入できない" do
         @order.house_number = ""
         @order.valid?
-        expect(@order.errors.full_messages).to include("House number can't be blank")
+        expect(@order.errors.full_messages).to include("番地を入力してください") # "House number can't be blank"
       end
 
       it "電話番号(phone_number)が空では購入できない" do
         @order.phone_number = ""
         @order.valid?
-        expect(@order.errors.full_messages).to include("Phone number can't be blank")
+        expect(@order.errors.full_messages).to include("電話番号を入力してください") # "Phone number can't be blank"
       end
 
       it "電話番号(phone_number)が数字以外の文字やハイフン( - )が含まれていると購入できない" do
         @order.phone_number = "123-4567890"
         @order.valid?
-        expect(@order.errors.full_messages).to include("Phone number Input only number")
+        expect(@order.errors.full_messages).to include("電話番号は半角数字で入力して下さい") # "Phone number Input only number"
       end
 
       it "電話番号にはハイフンは不要で、11桁以内であること（09012345678となる）" do
         @order.phone_number = "123456789000"
         @order.valid?
-        expect(@order.errors.full_messages).to include("Phone number Out of setting range")
+        expect(@order.errors.full_messages).to include("電話番号は10又は11桁の数値で入力して下さい") # "Phone number Out of setting range"
       end
 
       it "電話番号にはハイフンは不要で、10桁以上であること（0612345678となる）" do
         @order.phone_number = "123456789"
         @order.valid?
-        expect(@order.errors.full_messages).to include("Phone number Out of setting range")
+        expect(@order.errors.full_messages).to include("電話番号は10又は11桁の数値で入力して下さい") # "Phone number Out of setting range"
       end
 
       # ここから下は、システム(system・結合)
@@ -182,3 +182,5 @@ RSpec.describe TokenAddressOrder, type: :model do
     end
   end
 end
+
+# bundle exec rspec spec/models/token_address_order_spec.rb

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,107 +17,111 @@ RSpec.describe User, type: :model do
       it "nicknameが空だと登録できない" do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください") # "Nickname can't be blank"
       end
       it "emailが空では登録できない" do
         @user.email = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください") # "Email can't be blank"
       end
       it "重複したemailが存在する場合登録できない" do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
+        expect(another_user.errors.full_messages).to include("Eメールはすでに存在します") # "Email has already been taken"
       end
       it "emailに@が含まれていない場合登録できない" do
         @user.email = "abcdefg"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include("Eメールは不正な値です") # "Email is invalid"
       end
       it "passwordが空では登録できない" do
         @user.password = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください") # "Password can't be blank"
       end
       it "passwordが5文字以下であれば登録できない" do
         @user.password = "aa000"
         @user.password_confirmation = "aa000"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください") # "Password is too short (minimum is 6 characters)"
       end
       it "passwordが存在してもpassword_confirmationが空では登録できない" do
         @user.password_confirmation = ""
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード(確認用)とパスワードの入力が一致しません") # "Password confirmation doesn't match Password"
       end
       it "passwordが6文字以上でも英字のみでは登録できない" do
         @user.password = "abcdef"
         @user.password_confirmation = "abcdef"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です") # "Password is invalid"
       end
       it "passwordが6文字以上でも数字のみでは登録できない" do
         @user.password = "000000"
         @user.password_confirmation = "000000"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です") # "Password is invalid"
       end
       it "lastname(苗字)が空だと登録できない" do
         @user.lastname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Lastname can't be blank")
+        expect(@user.errors.full_messages).to include("お名前(全角) 苗字を入力してください") # "Lastname can't be blank"
       end
       it "lastname(苗字)が半角英数字だと登録できない" do
         @user.lastname = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Lastname Full-width characters")
+        expect(@user.errors.full_messages).to include("お名前(全角) 苗字は全角で入力して下さい") # "Lastname Full-width characters"
       end
       it "firstname(名前)が空だと登録できない" do
         @user.firstname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Firstname can't be blank")
+        expect(@user.errors.full_messages).to include("お名前(全角) 名前を入力してください") # "Firstname can't be blank"
       end
       it "firstname(名前)が半角英数字だと登録できない" do
         @user.firstname = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Firstname Full-width characters")
+        expect(@user.errors.full_messages).to include("お名前(全角) 名前は全角で入力して下さい") # "Firstname Full-width characters"
       end
       it "lastname_reading(苗字読み)が空だと登録できない" do
         @user.lastname_reading = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Lastname reading can't be blank")
+        expect(@user.errors.full_messages).to include("お名前カナ(全角) 苗字を入力してください") # "Lastname reading can't be blank"
       end
       it "lastname_reading(苗字読み)が半角英数字だと登録できない" do
         @user.lastname_reading = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Lastname reading Full-width katakana characters")
+        expect(@user.errors.full_messages).to include("お名前カナ(全角) 苗字は全角(カナ)で入力して下さい") # "Lastname reading Full-width katakana characters"
       end
       it "lastname_reading(苗字読み)が全角でもカタカナ以外だと登録できない" do
         @user.lastname_reading = 'ひらがな漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Lastname reading Full-width katakana characters")
+        expect(@user.errors.full_messages).to include("お名前カナ(全角) 苗字は全角(カナ)で入力して下さい") # "Lastname reading Full-width katakana characters"
       end
       it "firstname_reading(名前読み)が空だと登録できない" do
         @user.firstname_reading = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Firstname reading can't be blank")
+        expect(@user.errors.full_messages).to include("お名前カナ(全角) 名前を入力してください") # "Firstname reading can't be blank"
       end
       it "firstname_reading(名前読み)が半角英数字だと登録できない" do
         @user.firstname_reading = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Firstname reading Full-width katakana characters")
+        expect(@user.errors.full_messages).to include("お名前カナ(全角) 名前は全角(カナ)で入力して下さい") # "Firstname reading Full-width katakana characters"
       end
       it "firstname_reading(名前読み)が全角でもカタカナ以外だと登録できない" do
         @user.firstname_reading = 'ひらがな漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Firstname reading Full-width katakana characters")
+        expect(@user.errors.full_messages).to include("お名前カナ(全角) 名前は全角(カナ)で入力して下さい") # "Firstname reading Full-width katakana characters"
       end
       it "birth_date(誕生日)が空だと登録できない" do
         @user.birth_date = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birth date can't be blank")
+        binding.pry
+        expect(@user.errors.full_messages).to include("誕生日を入力してください") # "Birth date can't be blank"
       end
     end
   end
 end
+
+# bundle exec rspec spec/models/user_spec.rb

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-I18n.locale = "en"
+# テストコードのメッセージを実行した際のエラーメッセージを初期化(デフォルトenを「無」へ)
+# I18n.locale = "en"
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
#What
【追加実装】
新規登録、ログイン、出品、購入画面における
エラーメッセージを英語表記から日本語表記へ変更

#Why
日本語での可読性を高める為